### PR TITLE
Add NCCL library to Flatpak bundle

### DIFF
--- a/ai.jan.Jan.yml
+++ b/ai.jan.Jan.yml
@@ -18,6 +18,19 @@ cleanup:
   - '*.a'
 
 modules:
+  # Ship Nvidia nccl which is not available in the default nvidia cuda runtime
+  - name: nccl
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://developer.download.nvidia.com/compute/redist/nccl/v2.27.7/nccl_2.27.7-1+cuda12.4_x86_64.txz
+        sha256: 944e1ba3a5ca9bbd449bbaed9796626122670e58dea3031837a3910a90ffd5ee
+        only-arches: [x86_64]
+    build-commands:
+      - install -Dm755 nccl_2.27.7-1+cuda12.4_x86_64/lib/libnccl.so /app/lib/libnccl.so
+      - install -Dm755 nccl_2.27.7-1+cuda12.4_x86_64/lib/libnccl.so.2 /app/lib/libnccl.so.2
+      - install -Dm755 nccl_2.27.7-1+cuda12.4_x86_64/lib/libnccl.so.2.27.7 /app/lib/libnccl.so.2.27.7
+
   - name: volk
     buildsystem: cmake-ninja
     builddir: true

--- a/ai.jan.Jan.yml
+++ b/ai.jan.Jan.yml
@@ -27,9 +27,9 @@ modules:
         sha256: 944e1ba3a5ca9bbd449bbaed9796626122670e58dea3031837a3910a90ffd5ee
         only-arches: [x86_64]
     build-commands:
-      - install -Dm755 nccl_2.27.7-1+cuda12.4_x86_64/lib/libnccl.so /app/lib/libnccl.so
-      - install -Dm755 nccl_2.27.7-1+cuda12.4_x86_64/lib/libnccl.so.2 /app/lib/libnccl.so.2
-      - install -Dm755 nccl_2.27.7-1+cuda12.4_x86_64/lib/libnccl.so.2.27.7 /app/lib/libnccl.so.2.27.7
+      - install -Dm755 lib/libnccl.so.2.27.7 /app/lib/libnccl.so.2.27.7
+      - ln -sf libnccl.so.2.27.7 /app/lib/libnccl.so.2
+      - ln -sf libnccl.so.2.27.7 /app/lib/libnccl.so
 
   - name: volk
     buildsystem: cmake-ninja


### PR DESCRIPTION
Ship Nvidia NCCL (Collective Communication Library) which is not available in the default nvidia cuda runtime. llama.cpp needs this now.