### PR TITLE
Update to v0.8.1

### DIFF
--- a/ai.jan.Jan.yml
+++ b/ai.jan.Jan.yml
@@ -50,12 +50,12 @@ modules:
     buildsystem: simple
     sources:
       - type: file
-        url: https://catalog.jan.ai/flatpak/Jan_0.8.0_amd64-flatpak.deb
-        sha256: 68bde193155f7a3149f776969976647be206215e02833924eca6b77259b277a0
+        url: https://catalog.jan.ai/flatpak/Jan_0.8.1_amd64-flatpak.deb
+        sha256: ce85a6a78b527ff56b863bb8e5e81712b4ea445351cb64ca3fbec9738d8b7327
         only-arches: [x86_64]
       - type: file
-        url: https://raw.githubusercontent.com/janhq/jan/b29157bb37157ab51120ba9aa6c0b64c5a2792b1/flatpak/ai.jan.Jan.metainfo.xml
-        sha256: 6a81d54de7117afa8094f9611ae2b57e3d5c4ca8adfbb86caeaabb93bf7f45bc
+        url: https://raw.githubusercontent.com/janhq/jan/ff2cbe2366b054f78feca635aa4aae91f344eac2/flatpak/ai.jan.Jan.metainfo.xml
+        sha256: 1bb13de12908ad40591080a6e11d5e9a250d4ecc5298f546dafdc16c772fcbf6
     build-commands:
       - ar -x *.deb
       - tar -xf data.tar.gz


### PR DESCRIPTION
Bump deb to Jan_0.8.1_amd64-flatpak.deb and repin metainfo.xml to commit ff2cbe2 with refreshed sha256 hashes.